### PR TITLE
Feature/marts comercial

### DIFF
--- a/models/marts/comercial/agg_salesperson_salesregion.sql
+++ b/models/marts/comercial/agg_salesperson_salesregion.sql
@@ -1,0 +1,96 @@
+with
+    stg_erp__salesorderheader as (
+        select
+            pk_pedido_venda
+            , fk_vendedor
+            , fk_territorio
+            , total_pagar
+        from {{ ref('stg_erp__salesorderheader') }}
+    )
+
+    , stg_erp__salesorderdetail as (
+        select
+            fk_pedido_venda
+            , quantidade_pedido * (preco_unitario - desconto_preco_unitario) as valor_pago_produto
+        from {{ ref('stg_erp__salesorderdetail') }}
+    )
+
+    , stg_erp__person as (
+        select
+            fk_entidade_negocio
+            , case
+                when nome_do_meio is null then (nome_primeiro || ' ' || nome_ultimo)
+                else (nome_primeiro || ' ' || nome_do_meio || ' ' || nome_ultimo) 
+            end as nome_completo
+        from {{ ref('stg_erp__person') }}
+    )
+
+    , stg_erp__employee as (
+        select
+            fk_entidade_negocio
+            , titulo_trabalho
+            , case
+                when indicador_ativo = True then 'Ativo'
+                else 'Inativo'
+            end as indicador_ativo
+        from {{ ref('stg_erp__employee') }}
+    )
+
+    , stg_erp__salesterritory as (
+        select
+            pk_territorio_venda
+            , codigo_regiao_pais
+        from {{ ref('stg_erp__salesterritory') }}
+    )
+
+    , stg_erp__countryregion as (
+        select
+            codigo_regiao_pais
+            , nome_regiao_pais
+        from {{ ref('stg_erp__countryregion') }}
+    )
+
+    , transformed_data as (
+        select 
+            stg_erp__salesorderheader.pk_pedido_venda
+            , stg_erp__salesorderheader.total_pagar
+            , stg_erp__salesorderdetail.valor_pago_produto
+            , stg_erp__person.nome_completo
+            , stg_erp__employee.titulo_trabalho
+            , stg_erp__employee.indicador_ativo
+            , stg_erp__countryregion.nome_regiao_pais
+        from stg_erp__salesorderheader
+        left join stg_erp__salesorderdetail
+            on  stg_erp__salesorderdetail.fk_pedido_venda = stg_erp__salesorderheader.pk_pedido_venda
+        left join stg_erp__person
+            on stg_erp__person.fk_entidade_negocio = stg_erp__salesorderheader.fk_vendedor
+        left join stg_erp__employee
+            on stg_erp__employee.fk_entidade_negocio = stg_erp__person.fk_entidade_negocio
+        left join stg_erp__salesterritory
+            on stg_erp__salesterritory.pk_territorio_venda = stg_erp__salesorderheader.fk_territorio
+        left join stg_erp__countryregion
+            on stg_erp__countryregion.codigo_regiao_pais = stg_erp__salesterritory.codigo_regiao_pais
+    )
+
+    , transformed_data_aggregated as (
+        select
+            nome_regiao_pais
+            , nome_completo
+            , titulo_trabalho
+            , indicador_ativo
+            , count(pk_pedido_venda) as total_vendas
+            , round(sum(total_pagar), 2) as total_receita_bruta
+            , sum(valor_pago_produto) as total_receita
+        from transformed_data
+        group by
+            nome_regiao_pais
+            , nome_completo
+            , titulo_trabalho
+            , indicador_ativo
+        order by
+            total_vendas desc
+    )
+
+select
+    *
+from transformed_data_aggregated

--- a/models/marts/comercial/agg_salesperson_salesregion.yml
+++ b/models/marts/comercial/agg_salesperson_salesregion.yml
@@ -1,0 +1,20 @@
+version: 2
+
+models:
+  - name: agg_salesperson_salesregion
+    description: "Modelo que agrega os dados de vendas, funcionários, e região para calcular total de vendas e receitas."
+    columns:
+      - name: nome_regiao_pais
+        description: "Nome da região do país associada ao pedido de venda."
+      - name: nome_completo
+        description: "Nome completo do vendedor associado ao pedido de venda."
+      - name: titulo_trabalho
+        description: "Título do trabalho do funcionário (vendedor)."
+      - name: indicador_ativo
+        description: "Indica se o funcionário (vendedor) está ativo ou inativo."
+      - name: total_vendas
+        description: "Número total de vendas associadas ao vendedor e região."
+      - name: total_receita_bruta
+        description: "Total da receita bruta gerada pelas vendas (sem descontos aplicados)."
+      - name: total_receita
+        description: "Total da receita líquida gerada pelas vendas, considerando os descontos aplicados."

--- a/models/marts/comercial/dim_creditcards.sql
+++ b/models/marts/comercial/dim_creditcards.sql
@@ -1,0 +1,35 @@
+with
+    stg_erp__salesorderheader as (
+        select
+            *
+        from {{ ref('stg_erp__salesorderheader') }}
+    )
+
+    , stg_erp__creditcard as (
+        select
+            *
+        from {{ ref('stg_erp__creditcard') }}
+    )
+
+    , transformed_data_creditcard as (
+        select
+            distinct (stg_erp__salesorderheader.fk_cartao_credito)
+            , stg_erp__creditcard.tipo_cartao
+            , stg_erp__creditcard.numero_cartao
+            , stg_erp__creditcard.mes_expiracao
+            , stg_erp__creditcard.ano_expiracao
+            , {{ 
+                dbt_utils.generate_surrogate_key([
+                    'stg_erp__salesorderheader.fk_cartao_credito'
+                    , 'stg_erp__creditcard.numero_cartao'
+                ]) 
+            }} as sk_creditcard
+        from stg_erp__salesorderheader
+        left join stg_erp__creditcard
+            on stg_erp__salesorderheader.fk_cartao_credito = stg_erp__creditcard.pk_cartao_credito
+        where fk_cartao_credito is not null
+    )
+
+select
+    *
+from transformed_data_creditcard

--- a/models/marts/comercial/dim_creditcards.yml
+++ b/models/marts/comercial/dim_creditcards.yml
@@ -1,0 +1,35 @@
+version: 2
+
+models:
+  - name: dim_creditcards
+    description: 'Dimensão que armazena informações transformadas de cartões de crédito a partir dos dados de pedidos de venda e cartões de crédito.'
+    columns:
+      - name: fk_cartao_credito
+        description: 'Chave estrangeira que referencia o cartão de crédito associado ao pedido de venda.'
+        tests:
+          - not_null
+          - relationships:
+              to: ref('stg_erp__creditcard')
+              field: pk_cartao_credito
+      - name: tipo_cartao
+        description: 'Tipo do cartão de crédito.'
+        tests:
+          - not_null
+      - name: numero_cartao
+        description: 'Número do cartão de crédito.'
+        tests:
+          - not_null
+          - unique
+      - name: mes_expiracao
+        description: 'Mês de expiração do cartão de crédito.'
+        tests:
+          - not_null
+      - name: ano_expiracao
+        description: 'Ano de expiração do cartão de crédito.'
+        tests:
+          - not_null
+      - name: sk_creditcard
+        description: 'Chave substituta (surrogate key) gerada para a dimensão do cartão de crédito.'
+        tests:
+          - unique
+          - not_null

--- a/models/marts/comercial/dim_customers.sql
+++ b/models/marts/comercial/dim_customers.sql
@@ -1,0 +1,60 @@
+with
+    stg_erp__salesorderheader as(
+        select
+            *
+        from {{ ref('stg_erp__salesorderheader') }}
+    )
+
+    , stg_erp__customer as(
+        select
+            *
+        from {{ ref('stg_erp__customer') }}
+    )
+
+    , stg_erp__store as(
+        select
+            *
+        from {{ ref('stg_erp__store') }}
+    )
+
+    , stg_erp__person as(
+        select
+            *
+        from {{ ref('stg_erp__person') }}
+    ) 
+    
+    , transformed_data_customers as(
+        select
+            distinct (stg_erp__salesorderheader.fk_cliente)
+            , stg_erp__customer.fk_pessoa
+            , stg_erp__customer.fk_loja
+            , stg_erp__person.fk_entidade_negocio
+            , case
+                when stg_erp__person.nome_do_meio is null then (
+                    stg_erp__person.nome_primeiro || ' ' || stg_erp__person.nome_ultimo
+                )
+                else (
+                    stg_erp__person.nome_primeiro || ' ' || stg_erp__person.nome_do_meio || ' ' || stg_erp__person.nome_ultimo
+                ) 
+            end as nome_completo
+            , stg_erp__store.nome_loja
+            , {{
+                dbt_utils.generate_surrogate_key([
+                    'stg_erp__salesorderheader.fk_cliente',
+                    'stg_erp__customer.fk_pessoa',
+                    'stg_erp__customer.fk_loja',
+                    'stg_erp__person.fk_entidade_negocio'
+                ])
+            }} as sk_cliente
+        from stg_erp__salesorderheader
+        left join stg_erp__customer
+            on stg_erp__salesorderheader.fk_cliente = stg_erp__customer.pk_cliente
+        left join stg_erp__store
+            on stg_erp__customer.fk_loja = stg_erp__store.fk_entidade_negocio
+        left join stg_erp__person
+            on stg_erp__customer.fk_pessoa = stg_erp__person.fk_entidade_negocio
+    )
+
+select
+    *
+from transformed_data_customers

--- a/models/marts/comercial/dim_customers.yml
+++ b/models/marts/comercial/dim_customers.yml
@@ -1,0 +1,44 @@
+version: 2
+
+models:
+  - name: dim_customers
+    description: 'Dimensão que armazena informações transformadas sobre clientes a partir dos dados de pedidos de venda, clientes, lojas e pessoas.'
+    columns:
+      - name: fk_cliente
+        description: 'Chave estrangeira que referencia o cliente associado ao pedido de venda.'
+        tests:
+          - not_null
+          - relationships:
+              to: ref('stg_erp__customer')
+              field: pk_cliente
+      - name: fk_pessoa
+        description: 'Chave estrangeira que referencia a pessoa associada ao cliente.'
+        tests:
+          - not_null
+          - relationships:
+              to: ref('stg_erp__person')
+              field: fk_entidade_negocio
+      - name: fk_loja
+        description: 'Chave estrangeira que referencia a loja associada ao cliente.'
+        tests:
+          - relationships:
+              to: ref('stg_erp__store')
+              field: fk_entidade_negocio
+      - name: fk_entidade_negocio
+        description: 'Chave estrangeira que referencia a entidade de negócio associada à pessoa.'
+        tests:
+          - not_null
+          - relationships:
+              to: ref('stg_erp__person')
+              field: fk_entidade_negocio
+      - name: nome_completo
+        description: 'Nome completo do cliente, composto de acordo com as informações disponíveis.'
+        tests:
+          - not_null
+      - name: nome_loja
+        description: 'Nome da loja associada ao cliente.'
+      - name: sk_cliente
+        description: 'Chave substituta (surrogate key) gerada para a dimensão do cliente.'
+        tests:
+          - unique
+          - not_null

--- a/models/marts/comercial/dim_locations.sql
+++ b/models/marts/comercial/dim_locations.sql
@@ -5,22 +5,10 @@ with
         from {{ ref('stg_erp__countryregion') }}
     )
 
-    , stg_erp__businessentityaddress as(
-        select
-            *
-        from {{ ref('stg_erp__businessentityaddress') }}
-    )
-
     , stg_erp__address as (
         select
             *
         from {{ ref('stg_erp__address') }}
-    )
-
-    , stg_erp__salesterritory as (
-        select
-            *
-        from {{ ref('stg_erp__salesterritory') }}
     )
 
     , stg_erp__stateprovince as (
@@ -38,26 +26,12 @@ with
     ,  transformed_data_locations as (
         select
             distinct(stg_erp__salesorderheader.fk_endereco_faturamento)
-            , stg_erp__salesorderheader.fk_territorio
-            , stg_erp__countryregion.codigo_regiao_pais
             , stg_erp__countryregion.nome_regiao_pais
-            , stg_erp__businessentityaddress.fk_entidade_negocio
-            , stg_erp__businessentityaddress.fk_endereco
-            , stg_erp__businessentityaddress.fk_tipo_endereco
-            , stg_erp__address.pk_endereco
-            , stg_erp__address.fk_estado_provincia
-            , stg_erp__address.endereco_primeiro
             , stg_erp__address.nome_cidade
-            , stg_erp__salesterritory.pk_territorio_venda
-            , stg_erp__salesterritory.nome_territorio
-            , stg_erp__stateprovince.pk_estado_provincia
-            , stg_erp__stateprovince.codigo_estado_provincia
             , stg_erp__stateprovince.nome_estado_provincia 
             , {{ 
                 dbt_utils.generate_surrogate_key([
-                    'stg_erp__businessentityaddress.fk_entidade_negocio', 
-                    'stg_erp__salesorderheader.fk_endereco_faturamento',
-                    'stg_erp__address.pk_endereco'
+                    'stg_erp__salesorderheader.fk_endereco_faturamento'
                 ]) 
             }} as sk_location
         from stg_erp__salesorderheader
@@ -65,12 +39,8 @@ with
             on stg_erp__salesorderheader.fk_endereco_envio = stg_erp__address.pk_endereco
         left join stg_erp__stateprovince
             on stg_erp__stateprovince.pk_estado_provincia = stg_erp__address.fk_estado_provincia
-        left join stg_erp__salesterritory
-            on stg_erp__salesterritory.pk_territorio_venda = stg_erp__salesorderheader.fk_territorio
         left join stg_erp__countryregion
             on stg_erp__countryregion.codigo_regiao_pais = stg_erp__stateprovince.codigo_regiao_pais
-        left join stg_erp__businessentityaddress
-            on stg_erp__businessentityaddress.fk_endereco = stg_erp__address.pk_endereco
     )
 
 select

--- a/models/marts/comercial/dim_locations.sql
+++ b/models/marts/comercial/dim_locations.sql
@@ -1,0 +1,78 @@
+with
+    stg_erp__countryregion as (
+        select 
+            *
+        from {{ ref('stg_erp__countryregion') }}
+    )
+
+    , stg_erp__businessentityaddress as(
+        select
+            *
+        from {{ ref('stg_erp__businessentityaddress') }}
+    )
+
+    , stg_erp__address as (
+        select
+            *
+        from {{ ref('stg_erp__address') }}
+    )
+
+    , stg_erp__salesterritory as (
+        select
+            *
+        from {{ ref('stg_erp__salesterritory') }}
+    )
+
+    , stg_erp__stateprovince as (
+        select
+            *
+        from {{ ref('stg_erp__stateprovince') }}
+    )
+
+    , stg_erp__salesorderheader as (
+        select
+            *
+        from {{ ref('stg_erp__salesorderheader') }}
+    )
+
+    ,  transformed_data_locations as (
+        select
+            distinct(stg_erp__salesorderheader.fk_endereco_faturamento)
+            , stg_erp__salesorderheader.fk_territorio
+            , stg_erp__countryregion.codigo_regiao_pais
+            , stg_erp__countryregion.nome_regiao_pais
+            , stg_erp__businessentityaddress.fk_entidade_negocio
+            , stg_erp__businessentityaddress.fk_endereco
+            , stg_erp__businessentityaddress.fk_tipo_endereco
+            , stg_erp__address.pk_endereco
+            , stg_erp__address.fk_estado_provincia
+            , stg_erp__address.endereco_primeiro
+            , stg_erp__address.nome_cidade
+            , stg_erp__salesterritory.pk_territorio_venda
+            , stg_erp__salesterritory.nome_territorio
+            , stg_erp__stateprovince.pk_estado_provincia
+            , stg_erp__stateprovince.codigo_estado_provincia
+            , stg_erp__stateprovince.nome_estado_provincia 
+            , {{ 
+                dbt_utils.generate_surrogate_key([
+                    'stg_erp__businessentityaddress.fk_entidade_negocio', 
+                    'stg_erp__salesorderheader.fk_endereco_faturamento',
+                    'stg_erp__address.pk_endereco'
+                ]) 
+            }} as sk_location
+        from stg_erp__salesorderheader
+        left join stg_erp__address
+            on stg_erp__salesorderheader.fk_endereco_envio = stg_erp__address.pk_endereco
+        left join stg_erp__stateprovince
+            on stg_erp__stateprovince.pk_estado_provincia = stg_erp__address.fk_estado_provincia
+        left join stg_erp__salesterritory
+            on stg_erp__salesterritory.pk_territorio_venda = stg_erp__salesorderheader.fk_territorio
+        left join stg_erp__countryregion
+            on stg_erp__countryregion.codigo_regiao_pais = stg_erp__stateprovince.codigo_regiao_pais
+        left join stg_erp__businessentityaddress
+            on stg_erp__businessentityaddress.fk_endereco = stg_erp__address.pk_endereco
+    )
+
+select
+    *
+from transformed_data_locations

--- a/models/marts/comercial/dim_locations.yml
+++ b/models/marts/comercial/dim_locations.yml
@@ -2,77 +2,33 @@ version: 2
 
 models:
   - name: dim_locations
-    description: 'Dimensão que armazena informações transformadas sobre localizações a partir de dados de endereços, territórios de vendas, estados/províncias e pedidos de venda.'
+    description: 'Dimensão que armazena informações sobre as localizações associadas aos endereços de faturamento dos pedidos, incluindo país, estado/província e cidade.'
     columns:
-      - name: codigo_regiao_pais
-        description: 'Código da região ou país associado à localização.'
+      - name: sk_location
+        description: 'Chave substituta (surrogate key) gerada para identificar unicamente cada localização com base no endereço de faturamento.'
         tests:
+          - unique
           - not_null
-          - relationships:
-              to: ref('stg_erp__countryregion')
-              field: codigo_regiao_pais
-      - name: nome_regiao_pais
-        description: 'Nome da região ou país associado à localização.'
-        tests:
-          - not_null
-      - name: fk_entidade_negocio
-        description: 'Chave estrangeira que referencia a entidade de negócio associada ao endereço.'
-        tests:
-          - not_null
-          - relationships:
-              to: ref('stg_erp__businessentityaddress')
-              field: fk_entidade_negocio
-      - name: fk_endereco
-        description: 'Chave estrangeira que referencia o endereço associado à entidade de negócio.'
+
+      - name: fk_endereco_faturamento
+        description: 'Chave estrangeira que referencia o endereço de faturamento do pedido.'
         tests:
           - not_null
           - relationships:
               to: ref('stg_erp__address')
               field: pk_endereco
-      - name: fk_tipo_endereco
-        description: 'Chave estrangeira que referencia o tipo de endereço associado à entidade de negócio.'
+
+      - name: nome_regiao_pais
+        description: 'Nome da região ou país relacionado ao endereço de faturamento.'
         tests:
           - not_null
-      - name: endereco_primeiro
-        description: 'Primeira linha do endereço.'
-        tests:
-          - not_null
+
       - name: nome_cidade
-        description: 'Nome da cidade associada ao endereço.'
+        description: 'Nome da cidade relacionada ao endereço de faturamento.'
         tests:
           - not_null
-      - name: pk_territorio_venda
-        description: 'Chave primária que identifica o território de venda associado à localização.'
-        tests:
-          - not_null
-          - relationships:
-              to: ref('stg_erp__salesterritory')
-              field: pk_territorio_venda
-      - name: nome_territorio
-        description: 'Nome do território de venda associado à localização.'
-      - name: pk_estado_provincia
-        description: 'Chave primária que identifica o estado ou província associado ao endereço.'
-        tests:
-          - not_null
-          - relationships:
-              to: ref('stg_erp__stateprovince')
-              field: pk_estado_provincia
-      - name: codigo_estado_provincia
-        description: 'Código do estado ou província associado ao endereço.'
-        tests:
-          - not_null
+
       - name: nome_estado_provincia
-        description: 'Nome do estado ou província associado ao endereço.'
-      - name: fk_endereco_faturamento
-        description: 'Chave estrangeira que referencia o endereço de faturamento associado ao pedido de venda.'
+        description: 'Nome do estado ou província relacionado ao endereço de faturamento.'
         tests:
-          - not_null
-      - name: fk_territorio
-        description: 'Chave estrangeira que referencia o território associado ao pedido de venda.'
-        tests:
-          - not_null
-      - name: sk_location
-        description: 'Chave substituta (surrogate key) gerada para a dimensão de localização.'
-        tests:
-          - unique
           - not_null

--- a/models/marts/comercial/dim_locations.yml
+++ b/models/marts/comercial/dim_locations.yml
@@ -1,0 +1,78 @@
+version: 2
+
+models:
+  - name: dim_locations
+    description: 'Dimensão que armazena informações transformadas sobre localizações a partir de dados de endereços, territórios de vendas, estados/províncias e pedidos de venda.'
+    columns:
+      - name: codigo_regiao_pais
+        description: 'Código da região ou país associado à localização.'
+        tests:
+          - not_null
+          - relationships:
+              to: ref('stg_erp__countryregion')
+              field: codigo_regiao_pais
+      - name: nome_regiao_pais
+        description: 'Nome da região ou país associado à localização.'
+        tests:
+          - not_null
+      - name: fk_entidade_negocio
+        description: 'Chave estrangeira que referencia a entidade de negócio associada ao endereço.'
+        tests:
+          - not_null
+          - relationships:
+              to: ref('stg_erp__businessentityaddress')
+              field: fk_entidade_negocio
+      - name: fk_endereco
+        description: 'Chave estrangeira que referencia o endereço associado à entidade de negócio.'
+        tests:
+          - not_null
+          - relationships:
+              to: ref('stg_erp__address')
+              field: pk_endereco
+      - name: fk_tipo_endereco
+        description: 'Chave estrangeira que referencia o tipo de endereço associado à entidade de negócio.'
+        tests:
+          - not_null
+      - name: endereco_primeiro
+        description: 'Primeira linha do endereço.'
+        tests:
+          - not_null
+      - name: nome_cidade
+        description: 'Nome da cidade associada ao endereço.'
+        tests:
+          - not_null
+      - name: pk_territorio_venda
+        description: 'Chave primária que identifica o território de venda associado à localização.'
+        tests:
+          - not_null
+          - relationships:
+              to: ref('stg_erp__salesterritory')
+              field: pk_territorio_venda
+      - name: nome_territorio
+        description: 'Nome do território de venda associado à localização.'
+      - name: pk_estado_provincia
+        description: 'Chave primária que identifica o estado ou província associado ao endereço.'
+        tests:
+          - not_null
+          - relationships:
+              to: ref('stg_erp__stateprovince')
+              field: pk_estado_provincia
+      - name: codigo_estado_provincia
+        description: 'Código do estado ou província associado ao endereço.'
+        tests:
+          - not_null
+      - name: nome_estado_provincia
+        description: 'Nome do estado ou província associado ao endereço.'
+      - name: fk_endereco_faturamento
+        description: 'Chave estrangeira que referencia o endereço de faturamento associado ao pedido de venda.'
+        tests:
+          - not_null
+      - name: fk_territorio
+        description: 'Chave estrangeira que referencia o território associado ao pedido de venda.'
+        tests:
+          - not_null
+      - name: sk_location
+        description: 'Chave substituta (surrogate key) gerada para a dimensão de localização.'
+        tests:
+          - unique
+          - not_null

--- a/models/marts/comercial/dim_products.sql
+++ b/models/marts/comercial/dim_products.sql
@@ -1,0 +1,56 @@
+with
+    stg_erp__salesorderheader as (
+        select
+            *
+        from {{ ref('stg_erp__salesorderheader') }}
+    )
+
+    , stg_erp__salesorderdetail as (
+        select
+            *
+        from {{ ref('stg_erp__salesorderdetail') }}
+    )
+
+    , stg_erp__product as (
+        select
+            *
+        from {{ ref('stg_erp__product') }}
+    )
+
+    , stg_erp__productcategory as (
+        select
+            *
+        from {{ ref('stg_erp__productcategory') }}
+    )
+
+    , stg_erp__productsubcategory as (
+        select
+            *
+        from {{ ref('stg_erp__productsubcategory') }}
+    )
+
+    , transformed_data_products as (
+        select 
+            distinct(stg_erp__salesorderdetail.fk_produto)
+            , stg_erp__product.fk_subcategoria_produto
+            , stg_erp__product.nome_produto
+            , stg_erp__productcategory.nome_categoria_produto
+            , stg_erp__productsubcategory.nome_subcategoria
+            , {{ 
+                dbt_utils.generate_surrogate_key([
+                    'stg_erp__salesorderdetail.fk_produto',
+                    'stg_erp__product.nome_produto'
+                ]) 
+            }} as sk_products
+        from stg_erp__salesorderdetail
+        left join stg_erp__product
+            on stg_erp__salesorderdetail.fk_produto = stg_erp__product.pk_produto
+        left join stg_erp__productsubcategory
+            on stg_erp__productsubcategory.pk_subcategoria_produto = stg_erp__product.fk_subcategoria_produto
+        left join stg_erp__productcategory
+            on stg_erp__productcategory.pk_categoria_produto = stg_erp__productsubcategory.fk_categoria_produto
+    )
+
+select
+    *
+from transformed_data_products

--- a/models/marts/comercial/dim_products.yml
+++ b/models/marts/comercial/dim_products.yml
@@ -1,0 +1,37 @@
+version: 2
+
+models:
+  - name: dim_products
+    description: 'Dimensão que armazena informações transformadas sobre produtos a partir de dados de pedidos de venda, produtos, categorias e subcategorias de produtos.'
+    columns:
+      - name: fk_produto
+        description: 'Chave estrangeira que referencia o produto associado ao pedido de venda.'
+        tests:
+          - not_null
+          - relationships:
+              to: ref('stg_erp__product')
+              field: pk_produto
+      - name: fk_subcategoria_produto
+        description: 'Chave estrangeira que referencia a subcategoria do produto.'
+        tests:
+          - not_null
+          - relationships:
+              to: ref('stg_erp__productsubcategory')
+              field: pk_subcategoria_produto
+      - name: nome_produto
+        description: 'Nome do produto.'
+        tests:
+          - not_null
+      - name: nome_categoria_produto
+        description: 'Nome da categoria à qual o produto pertence.'
+        tests:
+          - not_null
+      - name: nome_subcategoria
+        description: 'Nome da subcategoria à qual o produto pertence.'
+        tests:
+          - not_null
+      - name: sk_products
+        description: 'Chave substituta (surrogate key) gerada para a dimensão do produto.'
+        tests:
+          - unique
+          - not_null

--- a/models/marts/comercial/dim_salesreasons.sql
+++ b/models/marts/comercial/dim_salesreasons.sql
@@ -1,0 +1,39 @@
+with
+    stg_erp__salesreason as (
+        select
+            *
+        from {{ ref('stg_erp__salesreason') }}
+    )
+
+    , stg_erp__salesorderheadersalesreason as (
+        select
+            *
+        from {{ ref('stg_erp__salesorderheadersalesreason') }}
+    )
+
+    , transformed_data as (
+        select
+            stg_erp__salesorderheadersalesreason.fk_pedido_venda
+            , stg_erp__salesreason.nome_motivo
+        from stg_erp__salesorderheadersalesreason
+        left join stg_erp__salesreason
+            on stg_erp__salesreason.pk_motivo_venda = stg_erp__salesorderheadersalesreason.fk_motivo_venda
+    )
+
+    , transformed_data_salesreasons as (
+        select
+            fk_pedido_venda
+            , coalesce(listagg(nome_motivo, ', '), 'Sem Motivo') as nome_motivo_agregado
+            , {{
+                dbt_utils.generate_surrogate_key([
+                    'fk_pedido_venda',
+                    'nome_motivo_agregado'
+                ])
+            }} as sk_salesreasons
+        from transformed_data
+        group by fk_pedido_venda
+    )
+
+select
+    *
+from transformed_data_salesreasons

--- a/models/marts/comercial/dim_salesreasons.yml
+++ b/models/marts/comercial/dim_salesreasons.yml
@@ -1,0 +1,24 @@
+version: 2
+
+models:
+  - name: dim_salesreasons
+    description: 'Dimensão que agrega os motivos de venda relacionados a cada pedido, gerando uma lista de motivos e uma chave substituta para cada pedido de venda.'
+    columns:
+      - name: fk_pedido_venda
+        description: 'Chave estrangeira que referencia o pedido de venda associado aos motivos de venda.'
+        tests:
+          - not_null
+          - relationships:
+              to: ref('stg_erp__salesorderheadersalesreason')
+              field: fk_pedido_venda
+
+      - name: nome_motivo_agregado
+        description: 'Lista de motivos de venda associados ao pedido de venda. Caso não haja motivos, o valor será "Sem Motivo".'
+        tests:
+          - not_null
+
+      - name: sk_salesreasons
+        description: 'Chave substituta (surrogate key) gerada para identificar unicamente cada conjunto de motivos de venda agregados por pedido.'
+        tests:
+          - unique
+          - not_null

--- a/models/marts/comercial/fact_sales.sql
+++ b/models/marts/comercial/fact_sales.sql
@@ -1,0 +1,149 @@
+with
+    dim_creditcards as (
+        select
+            sk_creditcard
+            , fk_cartao_credito
+        from {{ ref('dim_creditcards') }}
+    )
+
+    , dim_customers as (
+        select
+            sk_cliente
+            , fk_cliente
+        from {{ ref('dim_customers') }}
+    )
+
+    ,  dim_locations as (
+        select
+            sk_location
+            , fk_endereco_faturamento
+        from {{ ref('dim_locations') }}
+    )
+
+    , dim_products as (
+        select
+            sk_products
+            , fk_produto
+        from {{ ref('dim_products') }}
+    )
+
+    , dim_salesreasons as (
+        select
+            fk_pedido_venda
+            , nome_motivo_agregado
+        from {{ ref('dim_salesreasons') }}
+    )
+
+    , stg_erp__salesorderdetail as (
+        select 
+            fk_pedido_venda
+            , fk_produto
+            , quantidade_pedido
+            , preco_unitario
+            , desconto_preco_unitario
+            , quantidade_pedido * (preco_unitario - desconto_preco_unitario) as valor_pago_produto
+        from {{ ref('stg_erp__salesorderdetail') }}
+    )
+
+    , stg_erp__salesorderheader as (
+        select
+            pk_pedido_venda
+            , fk_cliente
+            , fk_vendedor
+            , fk_territorio
+            , fk_endereco_faturamento
+            , fk_cartao_credito
+            , status_pedido
+            , case
+                when indicador_pedido_online = True then  'Online'
+                else 'Presencial'
+            end as indicador_pedido_online
+            , subtotal
+            , valor_imposto
+            , frete
+            , total_pagar
+            , data_pedido
+            , data_envio
+        from {{ ref('stg_erp__salesorderheader') }}
+    )
+
+    , join_stg_erp__salesorderdetail as (
+        select
+            stg_erp__salesorderdetail.fk_pedido_venda
+            , stg_erp__salesorderdetail.fk_produto
+            , stg_erp__salesorderdetail.quantidade_pedido
+            , stg_erp__salesorderdetail.preco_unitario
+            , stg_erp__salesorderdetail.desconto_preco_unitario
+            , stg_erp__salesorderdetail.valor_pago_produto
+            , ifnull(dim_salesreasons.nome_motivo_agregado, 'Sem informacao') as motivo_agregado
+        from stg_erp__salesorderdetail
+        left join dim_products
+            on dim_products.fk_produto = stg_erp__salesorderdetail.fk_produto
+        left join dim_salesreasons
+            on dim_salesreasons.fk_pedido_venda = stg_erp__salesorderdetail.fk_pedido_venda
+    )
+
+    , join_stg_erp__salesorderheader as (
+        select
+            stg_erp__salesorderheader.pk_pedido_venda
+            , stg_erp__salesorderheader.fk_cliente
+            , stg_erp__salesorderheader.fk_vendedor
+            , stg_erp__salesorderheader.fk_territorio
+            , stg_erp__salesorderheader.fk_endereco_faturamento
+            , stg_erp__salesorderheader.fk_cartao_credito
+            , stg_erp__salesorderheader.status_pedido
+            , stg_erp__salesorderheader.indicador_pedido_online
+            , stg_erp__salesorderheader.subtotal
+            , stg_erp__salesorderheader.valor_imposto
+            , stg_erp__salesorderheader.frete
+            , stg_erp__salesorderheader.total_pagar
+            , stg_erp__salesorderheader.data_pedido
+            , stg_erp__salesorderheader.data_envio
+        from stg_erp__salesorderheader
+        left join dim_customers
+            on dim_customers.fk_cliente = stg_erp__salesorderheader.fk_cliente
+        left join dim_creditcards
+            on dim_creditcards.fk_cartao_credito = stg_erp__salesorderheader.fk_cartao_credito
+        left join dim_locations
+            on dim_locations.fk_endereco_faturamento = stg_erp__salesorderheader.fk_endereco_faturamento
+    )
+
+    , transformed_data_factsales as (
+        select
+            join_stg_erp__salesorderdetail.fk_pedido_venda
+            , join_stg_erp__salesorderdetail.fk_produto
+            , join_stg_erp__salesorderheader.fk_cliente
+            , join_stg_erp__salesorderheader.fk_vendedor
+            , join_stg_erp__salesorderheader.fk_territorio
+            , join_stg_erp__salesorderheader.fk_endereco_faturamento
+            , join_stg_erp__salesorderheader.fk_cartao_credito
+            , join_stg_erp__salesorderdetail.quantidade_pedido
+            , join_stg_erp__salesorderdetail.preco_unitario
+            , join_stg_erp__salesorderdetail.desconto_preco_unitario
+            , join_stg_erp__salesorderdetail.valor_pago_produto
+            , join_stg_erp__salesorderdetail.motivo_agregado
+            , join_stg_erp__salesorderheader.status_pedido
+            , join_stg_erp__salesorderheader.indicador_pedido_online
+            , join_stg_erp__salesorderheader.subtotal
+            , join_stg_erp__salesorderheader.valor_imposto
+            , join_stg_erp__salesorderheader.frete
+            , join_stg_erp__salesorderheader.total_pagar
+            , join_stg_erp__salesorderheader.data_pedido
+            , join_stg_erp__salesorderheader.data_envio
+            , {{ dbt_utils.generate_surrogate_key([
+                    'join_stg_erp__salesorderdetail.fk_pedido_venda'
+                    , 'join_stg_erp__salesorderdetail.fk_produto'
+                    , 'join_stg_erp__salesorderheader.fk_cliente'
+                    , 'join_stg_erp__salesorderheader.fk_endereco_faturamento'
+                    , 'join_stg_erp__salesorderheader.fk_cartao_credito'
+                    , 'join_stg_erp__salesorderheader.data_pedido'
+                ]) 
+            }} as sk_factsales
+        from join_stg_erp__salesorderdetail
+        left join join_stg_erp__salesorderheader
+            on join_stg_erp__salesorderheader.pk_pedido_venda = join_stg_erp__salesorderdetail.fk_pedido_venda
+    )
+
+select 
+    *
+from transformed_data_factsales

--- a/models/marts/comercial/fact_sales.yml
+++ b/models/marts/comercial/fact_sales.yml
@@ -1,0 +1,119 @@
+version: 2
+
+models:
+  - name: fact_sales
+    description: 'Tabela fato que armazena informações detalhadas sobre as vendas, incluindo informações de clientes, produtos, endereços, cartões de crédito, motivos de venda, além de detalhes financeiros do pedido.'
+    columns:
+      - name: sk_factsales
+        description: 'Chave substituta (surrogate key) gerada para identificar unicamente cada fato de venda com base nos atributos chave do pedido e produto.'
+        tests:
+          - unique
+          - not_null
+
+      - name: fk_pedido_venda
+        description: 'Chave estrangeira que referencia o pedido de venda.'
+        tests:
+          - not_null
+          - relationships:
+              to: ref('stg_erp__salesorderheader')
+              field: pk_pedido_venda
+
+      - name: fk_produto
+        description: 'Chave estrangeira que referencia o produto associado ao pedido de venda.'
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_products')
+              field: fk_produto
+
+      - name: fk_cliente
+        description: 'Chave estrangeira que referencia o cliente associado ao pedido de venda.'
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_customers')
+              field: fk_cliente
+
+      - name: fk_vendedor
+        description: 'Chave estrangeira que referencia o vendedor associado ao pedido de venda.'
+
+      - name: fk_territorio
+        description: 'Chave estrangeira que referencia o território de vendas associado ao pedido de venda.'
+        tests:
+          - not_null
+
+      - name: fk_endereco_faturamento
+        description: 'Chave estrangeira que referencia o endereço de faturamento associado ao pedido de venda.'
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_locations')
+              field: fk_endereco_faturamento
+
+      - name: fk_cartao_credito
+        description: 'Chave estrangeira que referencia o cartão de crédito associado ao pedido de venda.'
+
+      - name: quantidade_pedido
+        description: 'Quantidade de produtos solicitados no pedido de venda.'
+        tests:
+          - not_null
+
+      - name: preco_unitario
+        description: 'Preço unitário do produto no pedido de venda.'
+        tests:
+          - not_null
+
+      - name: desconto_preco_unitario
+        description: 'Desconto aplicado ao preço unitário do produto.'
+        tests:
+          - not_null
+
+      - name: valor_pago_produto
+        description: 'Valor total pago pelo produto, considerando o preço unitário e os descontos aplicados.'
+        tests:
+          - not_null
+
+      - name: motivo_agregado
+        description: 'Motivo de venda agregado ao pedido, caso disponível. Caso contrário, o valor será "Sem informacao".'
+        tests:
+          - not_null
+
+      - name: status_pedido
+        description: 'Status do pedido de venda.'
+        tests:
+          - not_null
+
+      - name: indicador_pedido_online
+        description: 'Indica se o pedido foi realizado online.'
+        tests:
+          - not_null
+
+      - name: subtotal
+        description: 'Subtotal do pedido de venda (sem impostos e frete).'
+        tests:
+          - not_null
+
+      - name: valor_imposto
+        description: 'Valor dos impostos aplicados ao pedido.'
+        tests:
+          - not_null
+
+      - name: frete
+        description: 'Valor do frete cobrado no pedido.'
+        tests:
+          - not_null
+
+      - name: total_pagar
+        description: 'Valor total a pagar pelo pedido, incluindo impostos e frete.'
+        tests:
+          - not_null
+
+      - name: data_pedido
+        description: 'Data em que o pedido foi realizado.'
+        tests:
+          - not_null
+
+      - name: data_envio
+        description: 'Data em que o pedido foi enviado.'
+        tests:
+          - not_null


### PR DESCRIPTION
**Título do PR**: Criação de Marts do Comercial e Remoção da Pasta Intermediate

**Descrição:**
Este pull request implementa a criação de novas marts relacionadas ao comercial no Data Warehouse, além de realizar a remoção da pasta `intermediate`, que não possuía arquivos ou dados relevantes.

### Alterações:
1. **Criação de novos arquivos SQL e YML**:
   - **`agg_salesperson_salesregion.sql`**: Agregação de vendas por vendedor e região de vendas.
   - **`dim_creditcards.sql`**: Tabela de dimensão de cartões de crédito.
   - **`dim_customers.sql`**: Tabela de dimensão de clientes.
   - **`dim_locations.sql`**: Tabela de dimensão de localizações.
   - **`dim_products.sql`**: Tabela de dimensão de produtos.
   - **`dim_salesreasons.sql`**: Tabela de dimensão de motivos de vendas.
   - **`fact_sales.sql`**: Tabela de fatos de vendas.
   
2. **Arquivos YML para documentação e validação**:
   - Cada mart possui seu arquivo `.yml` correspondente, contendo as definições de metadados, descrições, testes de validação, e detalhes sobre colunas importantes.
   
3. **Remoção da pasta `intermediate`**:
   - A pasta `intermediate` foi removida, pois estava vazia e não é mais necessária neste momento do projeto.

### Tarefas realizadas:
- [x] Criação dos arquivos `.sql` para as marts do comercial.
- [x] Criação dos arquivos `.yml` correspondentes.
- [x] Remoção da pasta `intermediate`.
- [x] Testes realizados nas novas marts, verificando sua integridade e performance no ambiente de desenvolvimento.

### Como testar:
1. Executar as transformações no ambiente de desenvolvimento.
2. Verificar se as tabelas de marts foram criadas corretamente e estão retornando os dados esperados.
3. Validar que as agregações e dimensões estão com a lógica implementada de acordo com as regras de negócio.
4. Confirmar que a remoção da pasta `intermediate` não causou impacto em nenhuma outra parte do projeto.

### Impacto:
- As novas marts agregam funcionalidades importantes ao setor comercial, permitindo melhores análises de vendas, clientes, produtos, entre outros.
- A remoção da pasta `intermediate` ajuda a manter a organização e simplicidade do projeto.