### PR TITLE
modifica a materializacao dos arquivos em staging para views

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -43,7 +43,7 @@ models:
         +materialized: table
 
     staging:
-      +materialized: table
+      +materialized: view
       +schema: staging
       erp:
         +schema: stg_erp


### PR DESCRIPTION
**Descrição do Pull Request:**

Este Pull Request corrige a materialização e esquema de tabelas e views na camada de `staging`. A modificação foi necessária para corrigir inconsistências nos resultados de consultas relacionadas ao schema `stg_erp`. 

### Alterações:
- Alterado o tipo de materialização de:
  - `staging`: de `table` para `view`.
  - `erp`: alterado para utilizar o schema `stg_erp`.
  
### Problema:
Sem essas alterações, a consulta à referência `ref{{(stg_erp__salesorderdetail)}}` estava retornando resultados incorretos. Anteriormente, a contagem de `fk_pedido_venda` retornava 10.000 registros, enquanto o esperado era 121.317. Isso ocorreu devido à materialização incorreta das tabelas e views, resultando em erros nos dados carregados.

### Solução:
Com esta atualização, corrigimos a materialização para `view` e configuramos o schema correto para `erp` como `stg_erp`, o que garante que as referências e consultas retornem os resultados esperados.